### PR TITLE
Adding `ignore-certificate-errors` Chrome option

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,13 @@ func main() {
 		return
 	}
 
-	pctx, pcancel := chromedp.NewContext(context.Background())
+	copts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("ignore-certificate-errors", true),
+	)
+	ectx, ecancel := chromedp.NewExecAllocator(context.Background(), copts...)
+	defer ecancel()
+
+	pctx, pcancel := chromedp.NewContext(ectx)
 	defer pcancel()
 
 	// start the browser to ensure we end up making new tabs in an


### PR DESCRIPTION
page-fetch currently validates TLS certificates, which is generally an undesired feature for security tools. This PR adds the `ignore-certificate-errors` option to Chrome to disable certificate validation.

I have not extensively tested this, but it seems to work in line with Chrome against badssl.com