### PR TITLE
added bypass of headless detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,6 +106,15 @@ func main() {
 		copts = append(copts, chromedp.ProxyServer(opts.proxy))
 	}
 
+	// bypass chrome headless detection
+	copts = append(copts,
+		chromedp.UserAgent("Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0"),
+		chromedp.WindowSize(1920, 1080),
+		chromedp.NoFirstRun,
+		chromedp.NoDefaultBrowserCheck,
+		chromedp.Headless,
+		chromedp.DisableGPU)
+
 	ectx, ecancel := chromedp.NewExecAllocator(context.Background(), copts...)
 	defer ecancel()
 


### PR DESCRIPTION
Some sites detect and block versions of chrome headless. This can easily bypassed by using a common User-Agent.

I added a Firefox User-Agent and set the "window size" of the headless' browser instance to 1920, 1080.
I also added some other, which are good to have:
```
chromedp.NoFirstRun,
chromedp.NoDefaultBrowserCheck,
chromedp.Headless,
chromedp.DisableGPU
 ```